### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 dotted
 ======
 
-.. image:: https://pypip.in/version/dotted/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/dotted.svg?style=flat
     :target: https://pypi.python.org/pypi/dotted/
     :alt: Latest Version
 .. image:: https://travis-ci.org/carlosescri/DottedDict.svg?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20dotted))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `dotted`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.