### PR TITLE
Add check to __contains__(k)

### DIFF
--- a/dotted/collection.py
+++ b/dotted/collection.py
@@ -347,6 +347,9 @@ class DottedDict(DottedCollection, collections.MutableMapping):
             return self.store.__contains__(key)
 
         my_key, alt_key = split_key(key, 1)
+        # check it the key exists at this level first
+        if not self.store.__contains__(my_key): return False
+        # then get a new target
         target = self.store[my_key]
 
         if not isinstance(target, DottedCollection):

--- a/dotted/collection.py
+++ b/dotted/collection.py
@@ -347,7 +347,7 @@ class DottedDict(DottedCollection, collections.MutableMapping):
             return self.store.__contains__(key)
 
         my_key, alt_key = split_key(key, 1)
-        # check it the key exists at this level first
+        # check if the key exists at this level first
         if not self.store.__contains__(my_key): return False
         # then get a new target
         target = self.store[my_key]


### PR DESCRIPTION
Fixes #16 

Adds a check to see if the first level of the key exists before trying to retrieve the value.